### PR TITLE
CI support refresh to bring in line with Zeek

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,16 +14,16 @@ ci_template: &CI_TEMPLATE
 # Linux EOL timelines: https://linuxlifecycle.com/
 # Fedora (~13 months): https://fedoraproject.org/wiki/Fedora_Release_Life_Cycle
 
+fedora34_task:
+  container:
+    # Fedora 34 EOL: Around May 2022
+    dockerfile: ci/fedora-34/Dockerfile
+  << : *CI_TEMPLATE
+
 fedora33_task:
   container:
     # Fedora 33 EOL: Around November 2022
     dockerfile: ci/fedora-33/Dockerfile
-  << : *CI_TEMPLATE
-
-fedora32_task:
-  container:
-    # Fedora 32 EOL: Around May 2021
-    dockerfile: ci/fedora-32/Dockerfile
   << : *CI_TEMPLATE
 
 centos7_task:
@@ -36,6 +36,12 @@ centos8_task:
   container:
     # CentOS 8 EOL: May 31, 2029
     dockerfile: ci/centos-8/Dockerfile
+  << : *CI_TEMPLATE
+
+centosstream8_task:
+  container:
+    # Stream 8 support should be 5 years, so until 2024. but I cannot find a concrete timeline --cpk
+    dockerfile: ci/centos-stream-8/Dockerfile
   << : *CI_TEMPLATE
 
 debian10_task:
@@ -54,6 +60,18 @@ debian9_32bit_task:
   container:
     # Debian 9 EOL: June 2022
     dockerfile: ci/debian-9-32bit/Dockerfile
+  << : *CI_TEMPLATE
+
+opensuse_leap_15_2_task:
+  container:
+    # Opensuse Leap 15.2 EOL: Dec 2021
+    dockerfile: ci/opensuse-leap-15.2/Dockerfile
+  << : *CI_TEMPLATE
+
+opensuse_leap_15_3_task:
+  container:
+    # Opensuse Leap 15.3 EOL: TBD
+    dockerfile: ci/opensuse-leap-15.3/Dockerfile
   << : *CI_TEMPLATE
 
 ubuntu20_task:
@@ -89,6 +107,13 @@ macos_catalina_task:
   << : *CI_TEMPLATE
 
 # FreeBSD EOL timelines: https://www.freebsd.org/security/security.html#sup
+freebsd13_task:
+  freebsd_instance:
+    # FreeBSD 13 EOL: January 31, 2026
+    image_family: freebsd-13-0
+  prepare_script: ./ci/freebsd/prepare.sh
+  << : *CI_TEMPLATE
+
 freebsd12_task:
   freebsd_instance:
     # FreeBSD 12 EOL: June 30, 2024

--- a/ci/centos-stream-8/Dockerfile
+++ b/ci/centos-stream-8/Dockerfile
@@ -1,0 +1,8 @@
+FROM quay.io/centos/centos:stream8
+
+RUN dnf -y update && dnf -y install \
+    git \
+    cmake3 \
+    make \
+    gcc-c++ \
+  && dnf clean all && rm -rf /var/cache/dnf

--- a/ci/fedora-32/Dockerfile
+++ b/ci/fedora-32/Dockerfile
@@ -1,8 +1,0 @@
-FROM fedora:32
-
-RUN yum -y install \
-    git \
-    cmake \
-    make \
-    gcc-c++ \
-  && yum clean all && rm -rf /var/cache/yum

--- a/ci/fedora-34/Dockerfile
+++ b/ci/fedora-34/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:33
+FROM fedora:34
 
 RUN dnf -y install \
     git \

--- a/ci/opensuse-leap-15.2/Dockerfile
+++ b/ci/opensuse-leap-15.2/Dockerfile
@@ -1,0 +1,9 @@
+FROM opensuse/leap:15.2
+
+RUN zypper in -y \
+  gcc-c++ \
+  cmake \
+  git \
+  gzip \
+  make \
+  && rm -rf /var/cache/zypp

--- a/ci/opensuse-leap-15.3/Dockerfile
+++ b/ci/opensuse-leap-15.3/Dockerfile
@@ -1,0 +1,9 @@
+FROM opensuse/leap:15.3
+
+RUN zypper in -y \
+  gcc-c++ \
+  cmake \
+  git \
+  gzip \
+  make \
+  && rm -rf /var/cache/zypp


### PR DESCRIPTION
Drop Fedora 32, add Fedora 34, add Centos Stream, add OpenSUSE Leaps,
add FreeBSD 13. Also make Fedora 33 actually use Fedora 33. ;)