### PR TITLE
CI support refresh

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -44,6 +44,12 @@ centosstream8_task:
     dockerfile: ci/centos-stream-8/Dockerfile
   << : *CI_TEMPLATE
 
+debian11_task:
+  container:
+    # Debian 11 EOL: June 2026
+    dockerfile: ci/debian-11/Dockerfile
+  << : *CI_TEMPLATE
+
 debian10_task:
   container:
     # Debian 10 EOL: June 2024
@@ -84,12 +90,6 @@ ubuntu18_task:
   container:
     # Ubuntu 18.04 EOL: April 2023
     dockerfile: ci/ubuntu-18.04/Dockerfile
-  << : *CI_TEMPLATE
-
-ubuntu16_task:
-  container:
-    # Ubuntu 16.04 EOL: April 2021
-    dockerfile: ci/ubuntu-16.04/Dockerfile
   << : *CI_TEMPLATE
 
 # Apple doesn't publish official long-term support timelines.

--- a/ci/debian-11/Dockerfile
+++ b/ci/debian-11/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM debian:11
 
 ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
@@ -6,11 +6,5 @@ RUN apt-get update && apt-get -y install \
     git \
     cmake \
     make \
-    clang-8 \
-    libc++-8-dev \
-    libc++abi-8-dev \
+    g++ \
   && rm -rf /var/lib/apt/lists/*
-
-ENV CC=/usr/bin/clang-8
-ENV CXX=/usr/bin/clang++-8
-ENV CXXFLAGS=-stdlib=libc++


### PR DESCRIPTION
- Add Debian 11 (Bullseye)
- Drop Ubuntu 16.04